### PR TITLE
Take advantage of the application delegate

### DIFF
--- a/fast-cli/main.swift
+++ b/fast-cli/main.swift
@@ -11,18 +11,72 @@ import WebKit
 import AppKit
 import Combine
 
-
-let fastURL = URL(string: "https://fast.com")!
-
 typealias FastEvents = (speed: Int, unit: String)
 
-class NotificationScriptMessageHandler: NSObject, WKScriptMessageHandler {
+enum TimeoutError {
+    case stoppedReceivingEvents
+}
+
+class FastCLIDelegate: NSObject, NSApplicationDelegate, WKScriptMessageHandler {
 
     /// This was supposed to be a Subscriber but I kept getting a `Fatal error: API Violation: received an unexpected value before receiving a Subscription: file`. Perhaps I should make a custom publisher? 🤷‍♀️
-    let observer: PassthroughSubject<FastEvents, Never>
+    var observer: PassthroughSubject<FastEvents, Never>?
+    var webView: WKWebView?
+    var cancellables = Set<AnyCancellable>()
+    
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let userContentController = WKUserContentController()
+        let subject = PassthroughSubject<FastEvents, Never>()
 
-    init(observer: PassthroughSubject<FastEvents, Never>) {
-        self.observer = observer
+        /// Why can't this be a subscriber?
+        userContentController.add(self, name: "notification")
+
+        let source = """
+document.querySelector("#speed-value").addEventListener('DOMSubtreeModified', function(e) {
+    let units = document.querySelector("#speed-units").innerText
+    let value = e.srcElement.innerText
+    if (value) {
+        window.webkit.messageHandlers.notification.postMessage({ value: value, units: units });
+    }
+})
+"""
+
+        let userScript = WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
+        userContentController.addUserScript(userScript)
+
+        let configuration = WKWebViewConfiguration()
+        configuration.userContentController = userContentController
+
+        let webView = WKWebView(frame: CGRect.init(origin: .zero, size: CGSize(width: 100, height: 100)), configuration: configuration)
+        
+        self.webView = webView
+        self.observer = subject
+        
+        let nonDuplicateEvents = subject.removeDuplicates { (x, y) -> Bool in
+            return x.0 == y.0 && x.1 == y.1
+        }
+
+        /// Apparently, these need to exist and cant' be a `_`?
+        let x = nonDuplicateEvents.first().sink { (_) in
+            print("Started receiving speed data - waiting for it to stabilize.")
+        }
+        
+        /// Apparently, these need to exist and cant' be a `_`?
+        let y = nonDuplicateEvents.scan(nil, { (_, currentEvent) in
+                return currentEvent
+            }).timeout(5.0, scheduler: DispatchQueue.main)
+            .last()
+            .sink(receiveValue: { (event) in
+                if let finalEvent = event {
+                    print("Your speed is \(finalEvent.speed) \(finalEvent.unit)")
+                    NSApplication.shared.terminate(nil)
+                }
+            })
+        cancellables.insert(x)
+        cancellables.insert(y)
+        
+        let fastURL = URL(string: "https://fast.com")!
+        webView.load(URLRequest(url: fastURL))
     }
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
@@ -33,70 +87,11 @@ class NotificationScriptMessageHandler: NSObject, WKScriptMessageHandler {
                 return
         }
         /// Possible substitution: let value = (dict["value"] as? String).map{ Int($0) }
-        let _ = observer.send((value, units as String))
+        let _ = observer?.send((value, units as String))
     }
 }
 
-let userContentController = WKUserContentController()
-let subject = PassthroughSubject<FastEvents, Never>()
-
-/// Why can't this be a subscriber?
-let handler = NotificationScriptMessageHandler(observer: subject)
-userContentController.add(handler, name: "notification")
-
-let source = """
-document.querySelector("#speed-value").addEventListener('DOMSubtreeModified', function(e) {
-    let units = document.querySelector("#speed-units").innerText
-    let value = e.srcElement.innerText
-    if (value) {
-        window.webkit.messageHandlers.notification.postMessage({ value: value, units: units });
-    }
-})
-"""
-
-let userScript = WKUserScript(source: source, injectionTime: .atDocumentEnd, forMainFrameOnly: true)
-userContentController.addUserScript(userScript)
-
-let configuration = WKWebViewConfiguration()
-configuration.userContentController = userContentController
-
-let webView = WKWebView(frame: CGRect.init(origin: .zero, size: CGSize(width: 100, height: 100)), configuration: configuration)
-webView.load(URLRequest.init(url: fastURL))
-
-class XCCheckDelegate: NSObject, NSApplicationDelegate {
-    func applicationDidFinishLaunching(_ notification: Notification) {
-
-    }
-}
-
-
-let nonDuplicateEvents = subject.removeDuplicates { (x, y) -> Bool in
-    return x.0 == y.0 && x.1 == y.1
-}
-
-/// Apparently, these need to exist and cant' be a `_`?
-let x = nonDuplicateEvents.first().sink { (_) in
-    print("Started receiving speed data - waiting for it to stabilize.")
-}
-
-enum TimeoutError {
-    case stoppedReceivingEvents
-}
-
-/// Apparently, these need to exist and cant' be a `_`?
-let y = nonDuplicateEvents.scan(nil, { (_, currentEvent) in
-        return currentEvent
-    }).timeout(5.0, scheduler: DispatchQueue.main)
-    .last()
-    .sink(receiveValue: { (event) in
-        if let finalEvent = event {
-            print("Your speed is \(finalEvent.speed) \(finalEvent.unit)")
-            NSApplication.shared.terminate(nil)
-        }
-    })
-
-
-var delegate: XCCheckDelegate? = XCCheckDelegate()
+var delegate: FastCLIDelegate? = FastCLIDelegate()
 NSApplication.shared.delegate = delegate
 NSApplication.shared.run()
 delegate = nil


### PR DESCRIPTION
This moves all the loading and publisher setup to the "applicationDidFinishLaunching()" method.

Since you're using the `NSApplicationDelegate` trick for a long-running CLI, I think it makes more sense to start the loading process once your CLI "application" is done loading, just like a regular iOS or macOS application.

Therefore, I've moved all the WebView configuration and publisher setup to inside this method, and am now using properties to manage object lifetimes, instead of relying on top-level scoping to keep things around.