### PR TITLE
remove code signing ID

### DIFF
--- a/fast-cli.xcodeproj/project.pbxproj
+++ b/fast-cli.xcodeproj/project.pbxproj
@@ -247,8 +247,6 @@
 		42584052238099E0006078C5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7G2XZXD8B4;
 				ENABLE_HARDENED_RUNTIME = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -258,8 +256,6 @@
 		42584053238099E0006078C5 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = 7G2XZXD8B4;
 				ENABLE_HARDENED_RUNTIME = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
Not needed for the CLI app, and will prevent build errors on other people's machines :)